### PR TITLE
Add --face argument to launch webcam preview automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,13 @@ python run.py --execution-provider openvino
 -   Use a screen capture tool like OBS to stream.
 -   To change the face, select a new source image.
 
+**3. Automatic Webcam Mode**
+
+-   Execute `python run.py --face /faces/your_face_image.png`.
+-   The webcam preview will launch automatically with the selected face file.
+-   Use a screen capture tool like OBS to stream.
+-   To change the face, select a new source image.
+
 ## Command Line Arguments (Unmaintained)
 
 ```
@@ -266,6 +273,7 @@ options:
   --execution-provider {cpu} [{cpu} ...]                   available execution provider (choices: cpu, ...)
   --execution-threads EXECUTION_THREADS                    number of execution threads
   -v, --version                                            show program's version number and exit
+  --face FACE_PATH                                         select a face file from the /faces folder
 ```
 
 Looking for a CLI mode? Using the -s/--source argument will make the run program in cli mode.

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ python run.py --execution-provider openvino
 
 **3. Automatic Webcam Mode**
 
--   Execute `python run.py --face /faces/your_face_image.png`.
+-   Execute `python run.py --face faces/your_face_image.png`.
 -   The webcam preview will launch automatically with the selected face file.
 -   Use a screen capture tool like OBS to stream.
 -   To change the face, select a new source image.

--- a/modules/core.py
+++ b/modules/core.py
@@ -54,7 +54,6 @@ def parse_args() -> None:
     program.add_argument('--face', help='select a face file from the /faces folder', dest='face_path')  # P4e3a
 
     # register deprecated args
-    program.add_argument('-f', '--face', help=argparse.SUPPRESS, dest='source_path_deprecated')
     program.add_argument('--cpu-cores', help=argparse.SUPPRESS, dest='cpu_cores_deprecated', type=int)
     program.add_argument('--gpu-vendor', help=argparse.SUPPRESS, dest='gpu_vendor_deprecated')
     program.add_argument('--gpu-threads', help=argparse.SUPPRESS, dest='gpu_threads_deprecated', type=int)

--- a/modules/core.py
+++ b/modules/core.py
@@ -253,6 +253,6 @@ def run() -> None:
         start()
     else:
         window = ui.init(start, destroy, modules.globals.lang)
+        if modules.globals.face_path:  # Pa446
+            ui.webcam_preview(window, 0, modules.globals.face_path)  # Pa446
         window.mainloop()
-    if modules.globals.face_path:  # Pa446
-        ui.webcam_preview(window, 0)  # Pa446

--- a/modules/core.py
+++ b/modules/core.py
@@ -89,10 +89,6 @@ def parse_args() -> None:
         modules.globals.fp_ui['face_enhancer'] = False
 
     # translate deprecated args
-    if args.source_path_deprecated:
-        print('\033[33mArgument -f and --face are deprecated. Use -s and --source instead.\033[0m')
-        modules.globals.source_path = args.source_path_deprecated
-        modules.globals.output_path = normalize_output_path(args.source_path_deprecated, modules.globals.target_path, args.output_path)
     if args.cpu_cores_deprecated:
         print('\033[33mArgument --cpu-cores is deprecated. Use --execution-threads instead.\033[0m')
         modules.globals.execution_threads = args.cpu_cores_deprecated

--- a/modules/core.py
+++ b/modules/core.py
@@ -51,6 +51,7 @@ def parse_args() -> None:
     program.add_argument('--execution-provider', help='execution provider', dest='execution_provider', default=['cpu'], choices=suggest_execution_providers(), nargs='+')
     program.add_argument('--execution-threads', help='number of execution threads', dest='execution_threads', type=int, default=suggest_execution_threads())
     program.add_argument('-v', '--version', action='version', version=f'{modules.metadata.name} {modules.metadata.version}')
+    program.add_argument('--face', help='select a face file from the /faces folder', dest='face_path')  # P4e3a
 
     # register deprecated args
     program.add_argument('-f', '--face', help=argparse.SUPPRESS, dest='source_path_deprecated')
@@ -80,6 +81,7 @@ def parse_args() -> None:
     modules.globals.execution_providers = decode_execution_providers(args.execution_provider)
     modules.globals.execution_threads = args.execution_threads
     modules.globals.lang = args.lang
+    modules.globals.face_path = args.face_path  # P4e3a
 
     #for ENHANCER tumbler:
     if 'face_enhancer' in args.frame_processor:
@@ -257,3 +259,5 @@ def run() -> None:
     else:
         window = ui.init(start, destroy, modules.globals.lang)
         window.mainloop()
+    if modules.globals.face_path:  # Pa446
+        ui.webcam_preview(window, 0)  # Pa446

--- a/modules/globals.py
+++ b/modules/globals.py
@@ -41,3 +41,4 @@ show_mouth_mask_box = False
 mask_feather_ratio = 8
 mask_down_size = 0.50
 mask_size = 1
+face_path = None

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -777,13 +777,16 @@ def update_preview(frame_number: int = 0) -> None:
         PREVIEW.deiconify()
 
 
-def webcam_preview(root: ctk.CTk, camera_index: int):
+def webcam_preview(root: ctk.CTk, camera_index: int, face_path: str = None):
     global POPUP_LIVE
 
     if POPUP_LIVE and POPUP_LIVE.winfo_exists():
         update_status("Source x Target Mapper is already open.")
         POPUP_LIVE.focus()
         return
+
+    if face_path:
+        modules.globals.source_path = face_path
 
     if not modules.globals.map_faces:
         if modules.globals.source_path is None:


### PR DESCRIPTION
Add automatic webcam preview launch with `--face` argument in `run.py`.

* **modules/core.py**
  - Add `--face` argument to `parse_args` function to select a face file from the `/faces` folder.
  - Modify `run` function to automatically launch the webcam preview if the `--face` argument is provided.

* **modules/ui.py**
  - Modify `webcam_preview` function to accept a face file and default camera index as arguments.
  - Update `webcam_preview` function to handle the face file and default camera index.

* **README.md**
  - Add instructions for using the `--face` argument to launch the webcam preview automatically.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/pmdlt/Deep-Live-Cam/pull/1?shareId=b7904815-e4fd-4133-ae04-188cd0553147).