### PR TITLE
Hide webcam header in plain screen

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -884,7 +884,6 @@ def create_webcam_preview(camera_index: int):
 
     PREVIEW.overrideredirect(True)
     PREVIEW.geometry("{0}x{1}+0+0".format(PREVIEW.winfo_screenwidth(), PREVIEW.winfo_screenheight()))
-    PREVIEW.bind("<Escape>", lambda e: PREVIEW.withdraw())
 
     frame_processors = get_frame_processors_modules(modules.globals.frame_processors)
     source_image = None

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -881,32 +881,10 @@ def create_webcam_preview(camera_index: int):
 
     preview_label.configure(width=PREVIEW_DEFAULT_WIDTH, height=PREVIEW_DEFAULT_HEIGHT)
     PREVIEW.deiconify()
-    
-    # Create a flag to track if the user wants to exit
-    exit_preview = False
-    
-    def on_key_press(event):
-        nonlocal exit_preview
-        if event.keysym == 'Escape':
-            exit_preview = True
-    
-    # Set window to fullscreen mode more reliably
-    PREVIEW.attributes('-fullscreen', True)
-    
-    # Set keyboard bindings - add to multiple widgets to ensure key capture
-    PREVIEW.bind("<Key>", on_key_press)
-    preview_label.bind("<Key>", on_key_press)
-    ROOT.bind("<Key>", on_key_press)
-    
-    # Create a message about how to exit
-    exit_msg = ctk.CTkLabel(PREVIEW, text=_("Press ESC to exit"), 
-                           bg_color="black", text_color="white",
-                           corner_radius=10, padx=10, pady=5)
-    exit_msg.place(relx=0.5, rely=0.05, anchor="center")
-    
-    # Focus on preview to ensure key events work
-    PREVIEW.focus_set()
-    preview_label.focus_set()
+
+    PREVIEW.overrideredirect(True)
+    PREVIEW.geometry("{0}x{1}+0+0".format(PREVIEW.winfo_screenwidth(), PREVIEW.winfo_screenheight()))
+    PREVIEW.bind("<Escape>", lambda e: PREVIEW.withdraw())
 
     frame_processors = get_frame_processors_modules(modules.globals.frame_processors)
     source_image = None
@@ -915,15 +893,11 @@ def create_webcam_preview(camera_index: int):
     frame_count = 0
     fps = 0
 
-    while not exit_preview:
-        # Process events at the beginning of each loop iteration
-        ROOT.update()
-        
+    while True:
         ret, frame = cap.read()
         if not ret:
             break
 
-        # Rest of the frame processing code...
         temp_frame = frame.copy()
 
         if modules.globals.live_mirror:
@@ -933,6 +907,7 @@ def create_webcam_preview(camera_index: int):
             temp_frame = fit_image_to_size(
                 temp_frame, PREVIEW.winfo_width(), PREVIEW.winfo_height()
             )
+
         else:
             temp_frame = fit_image_to_size(
                 temp_frame, PREVIEW.winfo_width(), PREVIEW.winfo_height()
@@ -976,17 +951,6 @@ def create_webcam_preview(camera_index: int):
                 2,
             )
 
-        # Add an "ESC to exit" reminder on the frame
-        cv2.putText(
-            temp_frame,
-            "Press ESC to exit",
-            (10, temp_frame.shape[0] - 10),
-            cv2.FONT_HERSHEY_SIMPLEX,
-            0.7,
-            (255, 255, 255),
-            2,
-        )
-
         image = cv2.cvtColor(temp_frame, cv2.COLOR_BGR2RGB)
         image = Image.fromarray(image)
         image = ImageOps.contain(
@@ -994,17 +958,13 @@ def create_webcam_preview(camera_index: int):
         )
         image = ctk.CTkImage(image, size=image.size)
         preview_label.configure(image=image)
-        
-        # Short delay to allow UI events to be processed
-        PREVIEW.update_idletasks()
-        time.sleep(0.01)  # Small delay to allow UI events to be processed
+        ROOT.update()
 
-    # Clean up
+        if PREVIEW.state() == "withdrawn":
+            break
+
     cap.release()
-    ROOT.unbind("<Key>")  # Remove the temporary binding
-    PREVIEW.attributes('-fullscreen', False)  # Restore normal window
     PREVIEW.withdraw()
-    update_status("Preview closed")
 
 
 def create_source_target_popup_for_webcam(

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -882,6 +882,10 @@ def create_webcam_preview(camera_index: int):
     preview_label.configure(width=PREVIEW_DEFAULT_WIDTH, height=PREVIEW_DEFAULT_HEIGHT)
     PREVIEW.deiconify()
 
+    PREVIEW.overrideredirect(True)
+    PREVIEW.geometry("{0}x{1}+0+0".format(PREVIEW.winfo_screenwidth(), PREVIEW.winfo_screenheight()))
+    PREVIEW.bind("<Escape>", lambda e: PREVIEW.withdraw())
+
     frame_processors = get_frame_processors_modules(modules.globals.frame_processors)
     source_image = None
     prev_time = time.time()


### PR DESCRIPTION
Make the webcam open in plain screen without the window header.

* Add `overrideredirect(True)` to the `create_webcam_preview` function to hide the window header.
* Add `geometry` method to set the window size to full screen in the `create_webcam_preview` function.
* Add `bind` method to close the window on `Escape` key press in the `create_webcam_preview` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/pmdlt/DLC-Mediacom-Osaka/pull/2?shareId=9e837a1d-5c9e-4ed0-bbcf-de48ddf1059c).