### PR TITLE
Add max faces argument to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ options:
   --execution-threads EXECUTION_THREADS                    number of execution threads
   -v, --version                                            show program's version number and exit
   --face FACE_PATH                                         select a face file from the /faces folder
+  --max-faces MAX_FACES                                    limit the number of max swapped faces
 ```
 
 Looking for a CLI mode? Using the -s/--source argument will make the run program in cli mode.

--- a/modules/core.py
+++ b/modules/core.py
@@ -52,6 +52,7 @@ def parse_args() -> None:
     program.add_argument('--execution-threads', help='number of execution threads', dest='execution_threads', type=int, default=suggest_execution_threads())
     program.add_argument('-v', '--version', action='version', version=f'{modules.metadata.name} {modules.metadata.version}')
     program.add_argument('--face', help='select a face file from the /faces folder', dest='face_path')  # P4e3a
+    program.add_argument('--max-faces', help='limit the number of max swapped faces', dest='max_faces', type=int, default=None)  # P871c
 
     # register deprecated args
     program.add_argument('--cpu-cores', help=argparse.SUPPRESS, dest='cpu_cores_deprecated', type=int)
@@ -80,7 +81,8 @@ def parse_args() -> None:
     modules.globals.execution_providers = decode_execution_providers(args.execution_provider)
     modules.globals.execution_threads = args.execution_threads
     modules.globals.lang = args.lang
-    modules.globals.face_path = args.face_path  # P4e3a
+    modules.globals.face_path = args.face_path
+    modules.globals.max_faces = args.max_faces
 
     #for ENHANCER tumbler:
     if 'face_enhancer' in args.frame_processor:

--- a/modules/globals.py
+++ b/modules/globals.py
@@ -42,3 +42,4 @@ mask_feather_ratio = 8
 mask_down_size = 0.50
 mask_size = 1
 face_path = None
+max_faces = None

--- a/modules/processors/frame/face_swapper.py
+++ b/modules/processors/frame/face_swapper.py
@@ -105,6 +105,8 @@ def process_frame(source_face: Face, temp_frame: Frame) -> Frame:
     if modules.globals.many_faces:
         many_faces = get_many_faces(temp_frame)
         if many_faces:
+            if modules.globals.max_faces is not None:
+                many_faces = many_faces[:modules.globals.max_faces]
             for target_face in many_faces:
                 if source_face and target_face:
                     temp_frame = swap_face(source_face, target_face, temp_frame)
@@ -168,6 +170,8 @@ def process_frame_v2(temp_frame: Frame, temp_frame_path: str = "") -> Frame:
         if modules.globals.many_faces:
             if detected_faces:
                 source_face = default_source_face()
+                if modules.globals.max_faces is not None:
+                    detected_faces = detected_faces[:modules.globals.max_faces]
                 for target_face in detected_faces:
                     temp_frame = swap_face(source_face, target_face, temp_frame)
 


### PR DESCRIPTION
Add a new CLI argument `--max-faces` to limit the number of max swapped faces.

* **modules/core.py**
  - Add `--max-faces` argument to `parse_args` function.
  - Set `modules.globals.max_faces` to the parsed `--max-faces` argument.

* **modules/globals.py**
  - Add a new global variable `max_faces` with a default value of `None`.

* **modules/processors/frame/face_swapper.py**
  - Modify `process_frame` function to limit the number of faces processed based on `max_faces` value.
  - Add a check to ensure the number of faces processed does not exceed `max_faces`.

* **README.md**
  - Update documentation to include the new `--max-faces` argument.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/pmdlt/DLC-Mediacom-Osaka/pull/3?shareId=c3f93736-5d5c-4f64-b9f2-39b34615a647).