### PR TITLE
Add face argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ options:
   --execution-threads EXECUTION_THREADS                    number of execution threads
   -v, --version                                            show program's version number and exit
   --face FACE_PATH                                         select a face file from the /faces folder
+  --max-faces MAX_FACES                                    limit the number of max swapped faces
 ```
 
 Looking for a CLI mode? Using the -s/--source argument will make the run program in cli mode.

--- a/modules/core.py
+++ b/modules/core.py
@@ -52,6 +52,7 @@ def parse_args() -> None:
     program.add_argument('--execution-threads', help='number of execution threads', dest='execution_threads', type=int, default=suggest_execution_threads())
     program.add_argument('-v', '--version', action='version', version=f'{modules.metadata.name} {modules.metadata.version}')
     program.add_argument('--face', help='select a face file from the /faces folder', dest='face_path')  # P4e3a
+    program.add_argument('--max-faces', help='limit the number of max swapped faces', dest='max_faces', type=int, default=None)  # P871c
 
     # register deprecated args
     program.add_argument('--cpu-cores', help=argparse.SUPPRESS, dest='cpu_cores_deprecated', type=int)
@@ -80,7 +81,8 @@ def parse_args() -> None:
     modules.globals.execution_providers = decode_execution_providers(args.execution_provider)
     modules.globals.execution_threads = args.execution_threads
     modules.globals.lang = args.lang
-    modules.globals.face_path = args.face_path  # P4e3a
+    modules.globals.face_path = args.face_path
+    modules.globals.max_faces = args.max_faces
 
     #for ENHANCER tumbler:
     if 'face_enhancer' in args.frame_processor:

--- a/modules/globals.py
+++ b/modules/globals.py
@@ -42,3 +42,4 @@ mask_feather_ratio = 8
 mask_down_size = 0.50
 mask_size = 1
 face_path = None
+max_faces = None

--- a/modules/processors/frame/face_swapper.py
+++ b/modules/processors/frame/face_swapper.py
@@ -105,6 +105,8 @@ def process_frame(source_face: Face, temp_frame: Frame) -> Frame:
     if modules.globals.many_faces:
         many_faces = get_many_faces(temp_frame)
         if many_faces:
+            if modules.globals.max_faces is not None:
+                many_faces = many_faces[:modules.globals.max_faces]
             for target_face in many_faces:
                 if source_face and target_face:
                     temp_frame = swap_face(source_face, target_face, temp_frame)
@@ -168,6 +170,8 @@ def process_frame_v2(temp_frame: Frame, temp_frame_path: str = "") -> Frame:
         if modules.globals.many_faces:
             if detected_faces:
                 source_face = default_source_face()
+                if modules.globals.max_faces is not None:
+                    detected_faces = detected_faces[:modules.globals.max_faces]
                 for target_face in detected_faces:
                     temp_frame = swap_face(source_face, target_face, temp_frame)
 


### PR DESCRIPTION
This pull request introduces a new feature to limit the number of faces that can be swapped in a frame. The changes include updates to the command-line interface, argument parsing, and frame processing logic to support this new feature.

### Command-line Interface Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R277): Added a new command-line argument `--max-faces` to limit the number of faces that can be swapped.

### Argument Parsing:
* [`modules/core.py`](diffhunk://#diff-3ce7331d2312d26226cc786c5459f0cc68344b34036dcfeb8dec9853cab6aacbR55): Added parsing for the new `--max-faces` argument and updated the global variables to store its value. [[1]](diffhunk://#diff-3ce7331d2312d26226cc786c5459f0cc68344b34036dcfeb8dec9853cab6aacbR55) [[2]](diffhunk://#diff-3ce7331d2312d26226cc786c5459f0cc68344b34036dcfeb8dec9853cab6aacbL83-R85)
* [`modules/globals.py`](diffhunk://#diff-71a15e2c097e490af33ce21ad8cd6a80991f2d4519051b43d8c9508e0da45697R45): Added a new global variable `max_faces` to store the value of the `--max-faces` argument.

### Frame Processing:
* [`modules/processors/frame/face_swapper.py`](diffhunk://#diff-c7a637d5c59674af01664f97fe16d8713850df23e37e6619c7939c3fa324fc1cR108-R109): Updated the `process_frame` and `process_frame_v2` functions to limit the number of faces processed based on the `max_faces` value. [[1]](diffhunk://#diff-c7a637d5c59674af01664f97fe16d8713850df23e37e6619c7939c3fa324fc1cR108-R109) [[2]](diffhunk://#diff-c7a637d5c59674af01664f97fe16d8713850df23e37e6619c7939c3fa324fc1cR173-R174)